### PR TITLE
added usage and general description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,103 @@
-# IMAP Integration Component
+[![license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 
-## Overview
+# CUBA Platform Component - IMAP Email Client
 
-The purpose of the IMAP Integration CUBA component is to provide a readily available instrument that allows adding the capability to integrate email messaging into any application developed using CUBA.Platform.
+This application component can be used to extend the capabilities of a [CUBA.Platform](https://www.cuba-platform.com/) application so that it can retrieve Emails via the [IMAP protocol](https://tools.ietf.org/html/rfc3501).
+
+The main model to interact with incoming Emails is via Spring application Events. The application developer registeres Hook methods as an `@EventListener` which will invoked when Events in the IMAP mailbox happen (e.g. new Email received).
+
+Besides the Event based programming model it is also possible to directly interact with the corresponding API methods.
+
+## Installation
+
+1. Add the following maven repository `TBD` to the build.gradle of your CUBA application:
+
+
+    buildscript {
+        
+        //...
+        
+        repositories {
+        
+            // ...
+        
+            maven {
+                url  "TBD"
+            }
+        }
+        
+        // ...
+    }
+
+2. Select a version of the add-on which is compatible with the platform version used in your project:
+
+| Platform Version | Add-on Version |
+| ---------------- | -------------- |
+| 6.7.x            | 0.1.x-SNAPSHOT |
+
+
+The latest version is: TBD
+
+Add custom application component to your project:
+
+* Artifact group: `com.haulmont.addon.imap`
+* Artifact name: `imap-global`
+* Version: *add-on version*
+
+
+## Usage
+
+### IMAP encryption configuration options
+
+It is required to configure the following application properties in the `app.properties` of the application:
+```
+cuba.email.imap.encryption.key = HBXv3Q70IlmBMiW4EMyPHw==
+cuba.email.imap.encryption.iv = DYOKud/GWV5boeGvmR/ttg==
+```
+
+
+### Register EventListeners to interact with IMAP events
+In order to react to IMAP events in your application, you can register Service methods as Event listener through the `@EventListener` Annotation. 
+
+```
+import org.springframework.context.event.EventListener;
+
+public interface EmailReceiveService {
+    String NAME = "ceuia_EmailReceiveService";
+
+    @EventListener
+    void receiveEmail(NewEmailImapEvent event);
+}
+```
+
+with the corresponding ServiceBean:
+```
+import org.springframework.context.event.EventListener;
+
+@Service(EmailReceiveService.NAME)
+public class EmailReceiveServiceBean implements EmailReceiveService {
+
+    @EventListener
+    @Override
+    public void receiveEmail(NewEmailImapEvent event) {
+      // handle IMAP event
+    }
+}
+```
+
+Once this is done, the method (in this case `receiveEmail` has to be registered on a particular Folder for a given IMAP connection. This has to be done at runtime via the IMAP configuration UI.
+
+After that the method will get invoked every time when an event occurs.
+
+#### Event types
+
+The application component allows the following kind of IMAP events:
+
+* EmailAnsweredImapEvent
+* EmailSeenImapEvent
+* EmailFlagChangedImapEvent
+* NewEmailImapEvent
+* EmailDeletedImapEvent
+* EmailMovedImapEvent
+* NewThreadImapEvent
+


### PR DESCRIPTION
This PR adds a more detailed README. 

It contains a installation section which is *TBD* until you guys published it. 

In addition to that it adds a Usage section, which explains the common usage pattern. This is only a guess on how to use it properly or more or less what I found out on how to successfully use it. I'm not really sure what are your thoughts on that, so feel free to just replace the parts that are wrong / misleading.

It also contains a part regarding the application properties. I'm not really sure what is that - i just found out that if I configure it in the app's app.properties file it works. Perhaps you can add a little explanation here.

Thx