### PR TITLE
switched from IDEA toString generation to toStringBuilder

### DIFF
--- a/modules/global/src/com/haulmont/addon/imap/dto/ImapFolderDto.java
+++ b/modules/global/src/com/haulmont/addon/imap/dto/ImapFolderDto.java
@@ -5,6 +5,7 @@ import com.haulmont.chile.core.annotations.MetaProperty;
 import com.haulmont.chile.core.annotations.NamePattern;
 import com.haulmont.cuba.core.entity.AbstractNotPersistentEntity;
 import com.sun.mail.imap.IMAPFolder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.List;
 
@@ -97,11 +98,11 @@ public class ImapFolderDto extends AbstractNotPersistentEntity {
 
     @Override
     public String toString() {
-        return "MailFolderDto{" +
-                "name='" + name + '\'' +
-                ", fullName='" + fullName + '\'' +
-                ", canHoldMessages=" + canHoldMessages +
-                ", children=" + children +
-                '}';
+        return new ToStringBuilder(this).
+                append("name", name).
+                append("fullName", fullName).
+                append("canHoldMessages", canHoldMessages).
+                append("children", children).
+                toString();
     }
 }

--- a/modules/global/src/com/haulmont/addon/imap/dto/ImapMessageDto.java
+++ b/modules/global/src/com/haulmont/addon/imap/dto/ImapMessageDto.java
@@ -4,6 +4,7 @@ import com.haulmont.chile.core.annotations.MetaClass;
 import com.haulmont.chile.core.annotations.MetaProperty;
 import com.haulmont.chile.core.annotations.NamePattern;
 import com.haulmont.cuba.core.entity.AbstractNotPersistentEntity;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.Date;
 import java.util.List;
@@ -156,16 +157,16 @@ public class ImapMessageDto extends AbstractNotPersistentEntity {
 
     @Override
     public String toString() {
-        return "MailMessageDto{" +
-                "from='" + from + '\'' +
-                ", toList=" + toList +
-                ", ccList=" + ccList +
-                ", bccList=" + bccList +
-                ", subject='" + subject + '\'' +
-                ", body='" + body + '\'' +
-                ", flags=" + flags +
-                ", mailBoxHost='" + mailBoxHost + '\'' +
-                ", mailBoxPort='" + mailBoxPort + '\'' +
-                '}';
+        return new ToStringBuilder(this).
+                append("from", from).
+                append("toList", toList).
+                append("ccList", ccList).
+                append("bccList", bccList).
+                append("subject", subject).
+                append("body", body).
+                append("flags", flags).
+                append("mailBoxHost", mailBoxHost).
+                append("mailBoxPort", mailBoxPort).
+                toString();
     }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/BaseImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/BaseImapEvent.java
@@ -1,6 +1,7 @@
 package com.haulmont.addon.imap.events;
 
 import com.haulmont.addon.imap.entity.ImapMessage;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.springframework.context.ApplicationEvent;
 
 public abstract class BaseImapEvent extends ApplicationEvent {
@@ -16,10 +17,12 @@ public abstract class BaseImapEvent extends ApplicationEvent {
         return message;
     }
 
+
+
     @Override
     public String toString() {
-        return "BaseImapEvent{" +
-                "message=" + message +
-                '}';
+        return new ToStringBuilder(this).
+                append("message", message).
+                toString();
     }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/EmailAnsweredImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/EmailAnsweredImapEvent.java
@@ -8,10 +8,4 @@ public class EmailAnsweredImapEvent extends BaseImapEvent {
         super(message);
     }
 
-    @Override
-    public String toString() {
-        return "EmailAnsweredImapEvent{" +
-                "message=" + message +
-                '}';
-    }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/EmailDeletedImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/EmailDeletedImapEvent.java
@@ -8,10 +8,4 @@ public class EmailDeletedImapEvent extends BaseImapEvent {
         super(message);
     }
 
-    @Override
-    public String toString() {
-        return "EmailDeletedImapEvent{" +
-                "message=" + message +
-                '}';
-    }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/EmailFlagChangedImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/EmailFlagChangedImapEvent.java
@@ -2,6 +2,7 @@ package com.haulmont.addon.imap.events;
 
 import com.haulmont.addon.imap.api.ImapFlag;
 import com.haulmont.addon.imap.entity.ImapMessage;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.Map;
 
@@ -21,9 +22,9 @@ public class EmailFlagChangedImapEvent extends BaseImapEvent {
 
     @Override
     public String toString() {
-        return "EmailFlagChangedImapEvent{" +
-                "changedFlagsWithNewValue=" + changedFlagsWithNewValue +
-                ", message=" + message +
-                '}';
+        return new ToStringBuilder(this).
+                append("changedFlagsWithNewValue", changedFlagsWithNewValue).
+                append("message", message).
+                toString();
     }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/EmailMovedImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/EmailMovedImapEvent.java
@@ -1,6 +1,7 @@
 package com.haulmont.addon.imap.events;
 
 import com.haulmont.addon.imap.entity.ImapMessage;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class EmailMovedImapEvent extends BaseImapEvent {
 
@@ -22,9 +23,9 @@ public class EmailMovedImapEvent extends BaseImapEvent {
 
     @Override
     public String toString() {
-        return "EmailMovedImapEvent{" +
-                "newFolderName='" + newFolderName + '\'' +
-                ", message=" + message +
-                '}';
+        return new ToStringBuilder(this).
+                append("newFolderName", newFolderName).
+                append("message", message).
+                toString();
     }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/EmailSeenImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/EmailSeenImapEvent.java
@@ -8,10 +8,4 @@ public class EmailSeenImapEvent extends BaseImapEvent {
         super(message);
     }
 
-    @Override
-    public String toString() {
-        return "EmailSeenImapEvent{" +
-                "message=" + message +
-                '}';
-    }
 }

--- a/modules/global/src/com/haulmont/addon/imap/events/NewThreadImapEvent.java
+++ b/modules/global/src/com/haulmont/addon/imap/events/NewThreadImapEvent.java
@@ -8,10 +8,4 @@ public class NewThreadImapEvent extends BaseImapEvent {
         super(message);
     }
 
-    @Override
-    public String toString() {
-        return "NewThreadImapEvent{" +
-                "message=" + message +
-                '}';
-    }
 }


### PR DESCRIPTION
This PR switches the `toString` methods to Apache commons [ToStringBuilder](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/builder/ToStringBuilder.html) instead of using the IDEA code generation.

Should be more easily extensible then when an attribute is added as well as with this inheritance case, it is not necessary anymore to do the override in the subclasses again.